### PR TITLE
Remove setvbuf from the node main code.

### DIFF
--- a/src/cmd_vel_mux_node.cpp
+++ b/src/cmd_vel_mux_node.cpp
@@ -39,9 +39,6 @@
 /** Main node entry point. */
 int main(int argc, char ** argv)
 {
-  // Configures stdout stream for no buffering
-  setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
-
   rclcpp::init(argc, argv);
 
   // handle callbacks until shut down


### PR DESCRIPTION
This is no longer necessary as all logging output goes to stderr by default.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>