### PR TITLE
Integrate stamped and unstamped twist messages. 

### DIFF
--- a/config/mux_twists.yaml
+++ b/config/mux_twists.yaml
@@ -1,0 +1,38 @@
+# Created on: Feb 05, 2020
+#     Author: Jose Tomas Lorente
+# Configuration for subscribers to cmd_vel sources. This file is provided just as an example.
+# Typically automatic controllers, as ROS navigation stack should have the minimum priority
+#
+# Used with example.launch
+#
+# Individual subscriber configuration:
+#   name:           Source name
+#   topic:          The topic that provides cmd_vel messages
+#   timeout:        Time in seconds without incoming messages to consider this topic inactive
+#   priority:       Priority: an UNIQUE unsigned integer from 0 (lowest) to MAX_INT
+#   short_desc:     Short description
+
+/**:
+  ros__parameters:
+    subscribers:
+        default_input:
+          topic:       "input/default"
+          timeout:     0.1
+          priority:    0
+          short_desc:  "The default cmd_vel, controllers unaware that we are multiplexing cmd_vel should come here"
+        # navigation_stack:
+        #   topic:       "input/navigation"
+        #   timeout:     0.5
+        #   priority:    1
+        #   short_desc:  "Navigation stack controller"
+        # navigation_stack_controller:
+        #   topic:       "input/joystick"
+        #   timeout:     0.1
+        #   priority:    10
+        #   short_desc:  "Navigation stack remote control"
+        remote_control:
+          topic:       "walking_twist/manual"
+          timeout:     0.5
+          priority:    9
+          short_desc:  "Manual control"
+

--- a/config/mux_twists.yaml
+++ b/config/mux_twists.yaml
@@ -31,8 +31,9 @@
         #   priority:    10
         #   short_desc:  "Navigation stack remote control"
         remote_control:
-          topic:       "walking_twist/manual"
-          timeout:     0.5
-          priority:    9
-          short_desc:  "Manual control"
+          topic:        "walking_twist/manual"
+          timeout:      0.5
+          priority:     9
+          short_desc:   "Manual control"
+          stamped:      true
 

--- a/config/mux_twists.yaml
+++ b/config/mux_twists.yaml
@@ -14,6 +14,7 @@
 
 /**:
   ros__parameters:
+    default_frame: "ground"
     subscribers:
         # default_input:
         #   topic:       "input/default"

--- a/config/mux_twists.yaml
+++ b/config/mux_twists.yaml
@@ -15,11 +15,11 @@
 /**:
   ros__parameters:
     subscribers:
-        default_input:
-          topic:       "input/default"
-          timeout:     0.1
-          priority:    0
-          short_desc:  "The default cmd_vel, controllers unaware that we are multiplexing cmd_vel should come here"
+        # default_input:
+        #   topic:       "input/default"
+        #   timeout:     0.1
+        #   priority:    0
+        #   short_desc:  "The default cmd_vel, controllers unaware that we are multiplexing cmd_vel should come here"
         # navigation_stack:
         #   topic:       "input/navigation"
         #   timeout:     0.5

--- a/include/cmd_vel_mux/cmd_vel_mux.hpp
+++ b/include/cmd_vel_mux/cmd_vel_mux.hpp
@@ -124,6 +124,7 @@ private:
     rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
 
     std::string allowed_;
+    std::string frame_id_default_;
 
     void timerCallback(const std::string & key);
     void cmdVelCallback(

--- a/include/cmd_vel_mux/cmd_vel_mux.hpp
+++ b/include/cmd_vel_mux/cmd_vel_mux.hpp
@@ -51,17 +51,15 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 
-/*****************************************************************************
-** Namespaces
-*****************************************************************************/
-
+//=========================================================
+// Namespaces
+//=========================================================
 namespace cmd_vel_mux
 {
 
-/*****************************************************************************
- ** CmdVelMux
- *****************************************************************************/
-
+//=========================================================
+// CmdVelMux
+//=========================================================
 struct ParameterValues
 {
     std::string topic;      /**< The name of the topic */
@@ -71,7 +69,12 @@ struct ParameterValues
     bool stamped;           /**< TODO: make this node flexible for twist messages with or w/out stamps */
 };
 
-bool operator==(const ParameterValues & parameters1, const ParameterValues & parameters2)
+//=========================================================
+// Check that the parameter values are identical
+bool operator==(
+    const ParameterValues & parameters1,
+    const ParameterValues & parameters2
+)
 {
     if (parameters1.topic != parameters2.topic) {
         return false;
@@ -87,6 +90,7 @@ bool operator==(const ParameterValues & parameters1, const ParameterValues & par
     return true;
 }
 
+//=========================================================
 class CmdVelMux final : public rclcpp::Node
 {
 public:
@@ -103,6 +107,7 @@ private:
 
     /// Multiplexed command velocity topic
     rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr output_topic_pub_;
+
     /// Currently allowed cmd_vel subscriber
     rclcpp::Publisher<std_msgs::msg::String>::SharedPtr active_subscriber_pub_;
     rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
@@ -114,11 +119,8 @@ private:
         const std::shared_ptr<geometry_msgs::msg::TwistStamped> msg,
         const std::string & key);
 
-    rcl_interfaces::msg::SetParametersResult parameterUpdate(
-        const std::vector<rclcpp::Parameter> & update_parameters);
-
     /*********************
-     ** Private Structs
+     ** Private Struct
     **********************/
 
     /**
@@ -135,17 +137,19 @@ private:
         rclcpp::TimerBase::SharedPtr timer_;
     };
 
-    bool addInputToParameterMap(
-        std::map<std::string, ParameterValues> & parsed_parameters,
-        const std::string & input_name, const std::string & parameter_name,
-        const rclcpp::Parameter & parameter_value);
     bool parametersAreValid(
         const std::map<std::string, ParameterValues> & parameters) const;
     void configureFromParameters(
         const std::map<std::string, ParameterValues> & parameters);
+    bool addInputToParameterMap(
+        std::map<std::string, ParameterValues> & parsed_parameters,
+        const std::string & input_name, const std::string & parameter_name,
+        const rclcpp::Parameter & parameter_value);
     std::map<std::string, ParameterValues> parseFromParametersMap(
         const std::map<std::string,
         rclcpp::Parameter> & parameters);
+    rcl_interfaces::msg::SetParametersResult parameterUpdate(
+        const std::vector<rclcpp::Parameter> & update_parameters);
 
     std::map<std::string, std::shared_ptr<CmdVelSub>> map_;
 };

--- a/include/cmd_vel_mux/cmd_vel_mux.hpp
+++ b/include/cmd_vel_mux/cmd_vel_mux.hpp
@@ -69,6 +69,17 @@ struct ParameterValues
     bool stamped;           /**< TODO: make this node flexible for twist messages with or w/out stamps */
 };
 
+//-------------------------------------
+struct CmdVelProperties final
+    {
+        /// Descriptive name; must be unique to this subscriber
+        std::string name_;
+        ParameterValues values_;
+        /// The subscriber itself
+        /// No incoming messages timeout
+        rclcpp::TimerBase::SharedPtr timer_;
+    };
+
 //=========================================================
 // Check that the parameter values are identical
 bool operator==(
@@ -123,24 +134,9 @@ private:
         const std::string & key);
     bool checkToPublish(const std::string & key);
 
-    /*********************
-     ** Private Struct
-    **********************/
-
-    /**
-     * Inner struct describing an individual subscriber to a cmd_vel topic
-     */
-    struct CmdVelSub final
-    {
-        /// Descriptive name; must be unique to this subscriber
-        std::string name_;
-        ParameterValues values_;
-        /// The subscriber itself
-        rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_;
-        /// No incoming messages timeout
-        rclcpp::TimerBase::SharedPtr timer_;
-    };
-
+    std::map<std::string, ParameterValues> parseFromParametersMap(
+        const std::map<std::string,
+        rclcpp::Parameter> & parameters);
     bool parametersAreValid(
         const std::map<std::string, ParameterValues> & parameters) const;
     void configureFromParameters(
@@ -149,13 +145,12 @@ private:
         std::map<std::string, ParameterValues> & parsed_parameters,
         const std::string & input_name, const std::string & parameter_name,
         const rclcpp::Parameter & parameter_value);
-    std::map<std::string, ParameterValues> parseFromParametersMap(
-        const std::map<std::string,
-        rclcpp::Parameter> & parameters);
     rcl_interfaces::msg::SetParametersResult parameterUpdate(
         const std::vector<rclcpp::Parameter> & update_parameters);
 
-    std::map<std::string, std::shared_ptr<CmdVelSub>> map_;
+    std::map<std::string, std::shared_ptr<CmdVelProperties>> map_;
+    std::map<std::string, rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr> map_subs_;
+    std::map<std::string, rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr> map_stamped_subs_;
 };
 
 }  // namespace cmd_vel_mux

--- a/include/cmd_vel_mux/cmd_vel_mux.hpp
+++ b/include/cmd_vel_mux/cmd_vel_mux.hpp
@@ -46,7 +46,7 @@
 #include <string>
 #include <vector>
 
-#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -64,10 +64,11 @@ namespace cmd_vel_mux
 
 struct ParameterValues
 {
-    std::string topic;       /**< The name of the topic */
-    double timeout{-1.0};    /**< Timer's timeout, in seconds  */
-    int64_t priority{-1};    /**< UNIQUE integer from 0 (lowest priority) to MAX_INT */
-    std::string short_desc;  /**< Short description */
+    std::string topic;      /**< The name of the topic */
+    double timeout{-1.0};   /**< Timer's timeout, in seconds  */
+    int64_t priority{-1};   /**< UNIQUE integer from 0 (lowest priority) to MAX_INT */
+    std::string short_desc; /**< Short description */
+    bool stamped;           /**< TODO: make this node flexible for twist messages with or w/out stamps */
 };
 
 bool operator==(const ParameterValues & parameters1, const ParameterValues & parameters2)
@@ -79,6 +80,8 @@ bool operator==(const ParameterValues & parameters1, const ParameterValues & par
     } else if (parameters1.priority != parameters2.priority) {
         return false;
     } else if (parameters1.short_desc != parameters2.short_desc) {
+        return false;
+    } else if (parameters1.stamped != parameters2.stamped) {
         return false;
     }
     return true;
@@ -99,7 +102,7 @@ private:
     static const char * const VACANT;
 
     /// Multiplexed command velocity topic
-    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr output_topic_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr output_topic_pub_;
     /// Currently allowed cmd_vel subscriber
     rclcpp::Publisher<std_msgs::msg::String>::SharedPtr active_subscriber_pub_;
     rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
@@ -108,7 +111,7 @@ private:
 
     void timerCallback(const std::string & key);
     void cmdVelCallback(
-        const std::shared_ptr<geometry_msgs::msg::Twist> msg,
+        const std::shared_ptr<geometry_msgs::msg::TwistStamped> msg,
         const std::string & key);
 
     rcl_interfaces::msg::SetParametersResult parameterUpdate(
@@ -127,7 +130,7 @@ private:
         std::string name_;
         ParameterValues values_;
         /// The subscriber itself
-        rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_;
+        rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_;
         /// No incoming messages timeout
         rclcpp::TimerBase::SharedPtr timer_;
     };

--- a/include/cmd_vel_mux/cmd_vel_mux.hpp
+++ b/include/cmd_vel_mux/cmd_vel_mux.hpp
@@ -116,8 +116,12 @@ private:
 
     void timerCallback(const std::string & key);
     void cmdVelCallback(
+        const std::shared_ptr<geometry_msgs::msg::Twist> msg,
+        const std::string & key);
+    void cmdVelStampedCallback(
         const std::shared_ptr<geometry_msgs::msg::TwistStamped> msg,
         const std::string & key);
+    bool checkToPublish(const std::string & key);
 
     /*********************
      ** Private Struct

--- a/include/cmd_vel_mux/cmd_vel_mux.hpp
+++ b/include/cmd_vel_mux/cmd_vel_mux.hpp
@@ -64,87 +64,87 @@ namespace cmd_vel_mux
 
 struct ParameterValues
 {
-  std::string topic;       /**< The name of the topic */
-  double timeout{-1.0};    /**< Timer's timeout, in seconds  */
-  int64_t priority{-1};    /**< UNIQUE integer from 0 (lowest priority) to MAX_INT */
-  std::string short_desc;  /**< Short description */
+    std::string topic;       /**< The name of the topic */
+    double timeout{-1.0};    /**< Timer's timeout, in seconds  */
+    int64_t priority{-1};    /**< UNIQUE integer from 0 (lowest priority) to MAX_INT */
+    std::string short_desc;  /**< Short description */
 };
 
 bool operator==(const ParameterValues & parameters1, const ParameterValues & parameters2)
 {
-  if (parameters1.topic != parameters2.topic) {
-    return false;
-  } else if (parameters1.timeout != parameters2.timeout) {
-    return false;
-  } else if (parameters1.priority != parameters2.priority) {
-    return false;
-  } else if (parameters1.short_desc != parameters2.short_desc) {
-    return false;
-  }
-  return true;
+    if (parameters1.topic != parameters2.topic) {
+        return false;
+    } else if (parameters1.timeout != parameters2.timeout) {
+        return false;
+    } else if (parameters1.priority != parameters2.priority) {
+        return false;
+    } else if (parameters1.short_desc != parameters2.short_desc) {
+        return false;
+    }
+    return true;
 }
 
 class CmdVelMux final : public rclcpp::Node
 {
 public:
-  explicit CmdVelMux(rclcpp::NodeOptions options);
-  ~CmdVelMux() override = default;
-  CmdVelMux(CmdVelMux && c) = delete;
-  CmdVelMux & operator=(CmdVelMux && c) = delete;
-  CmdVelMux(const CmdVelMux & c) = delete;
-  CmdVelMux & operator=(const CmdVelMux & c) = delete;
+    explicit CmdVelMux(rclcpp::NodeOptions options);
+    ~CmdVelMux() override = default;
+    CmdVelMux(CmdVelMux && c) = delete;
+    CmdVelMux & operator=(CmdVelMux && c) = delete;
+    CmdVelMux(const CmdVelMux & c) = delete;
+    CmdVelMux & operator=(const CmdVelMux & c) = delete;
 
 private:
-  /// ID for "nobody" active input
-  static const char * const VACANT;
+    /// ID for "nobody" active input
+    static const char * const VACANT;
 
-  /// Multiplexed command velocity topic
-  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr output_topic_pub_;
-  /// Currently allowed cmd_vel subscriber
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr active_subscriber_pub_;
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
+    /// Multiplexed command velocity topic
+    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr output_topic_pub_;
+    /// Currently allowed cmd_vel subscriber
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr active_subscriber_pub_;
+    rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
 
-  std::string allowed_;
+    std::string allowed_;
 
-  void timerCallback(const std::string & key);
-  void cmdVelCallback(
-    const std::shared_ptr<geometry_msgs::msg::Twist> msg,
-    const std::string & key);
+    void timerCallback(const std::string & key);
+    void cmdVelCallback(
+        const std::shared_ptr<geometry_msgs::msg::Twist> msg,
+        const std::string & key);
 
-  rcl_interfaces::msg::SetParametersResult parameterUpdate(
-    const std::vector<rclcpp::Parameter> & update_parameters);
+    rcl_interfaces::msg::SetParametersResult parameterUpdate(
+        const std::vector<rclcpp::Parameter> & update_parameters);
 
-  /*********************
-   ** Private Classes
-   **********************/
+    /*********************
+     ** Private Structs
+    **********************/
 
-  /**
-   * Inner class describing an individual subscriber to a cmd_vel topic
-   */
-  struct CmdVelSub final
-  {
-    /// Descriptive name; must be unique to this subscriber
-    std::string name_;
-    ParameterValues values_;
-    /// The subscriber itself
-    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_;
-    /// No incoming messages timeout
-    rclcpp::TimerBase::SharedPtr timer_;
-  };
+    /**
+     * Inner struct describing an individual subscriber to a cmd_vel topic
+     */
+    struct CmdVelSub final
+    {
+        /// Descriptive name; must be unique to this subscriber
+        std::string name_;
+        ParameterValues values_;
+        /// The subscriber itself
+        rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_;
+        /// No incoming messages timeout
+        rclcpp::TimerBase::SharedPtr timer_;
+    };
 
-  bool addInputToParameterMap(
-    std::map<std::string, ParameterValues> & parsed_parameters,
-    const std::string & input_name, const std::string & parameter_name,
-    const rclcpp::Parameter & parameter_value);
-  bool parametersAreValid(
-    const std::map<std::string, ParameterValues> & parameters) const;
-  void configureFromParameters(
-    const std::map<std::string, ParameterValues> & parameters);
-  std::map<std::string, ParameterValues> parseFromParametersMap(
-    const std::map<std::string,
-    rclcpp::Parameter> & parameters);
+    bool addInputToParameterMap(
+        std::map<std::string, ParameterValues> & parsed_parameters,
+        const std::string & input_name, const std::string & parameter_name,
+        const rclcpp::Parameter & parameter_value);
+    bool parametersAreValid(
+        const std::map<std::string, ParameterValues> & parameters) const;
+    void configureFromParameters(
+        const std::map<std::string, ParameterValues> & parameters);
+    std::map<std::string, ParameterValues> parseFromParametersMap(
+        const std::map<std::string,
+        rclcpp::Parameter> & parameters);
 
-  std::map<std::string, std::shared_ptr<CmdVelSub>> map_;
+    std::map<std::string, std::shared_ptr<CmdVelSub>> map_;
 };
 
 }  // namespace cmd_vel_mux

--- a/launch/mux_twists.launch.py
+++ b/launch/mux_twists.launch.py
@@ -50,6 +50,7 @@ def generate_launch_description():
 
     # Remap the default topic
     remappings = []
+    remappings.append( ("active", topics().walking_twist_active))
     remappings.append( ("cmd_vel", topics().walking_twist_muxed) )
     # Overwrite the config file with system globals
     remappings.append( ("walking_twist/manual", topics().walking_twist_manual) )

--- a/launch/mux_twists.launch.py
+++ b/launch/mux_twists.launch.py
@@ -1,0 +1,65 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Software License Agreement (BSD License 2.0)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the following
+#   disclaimer in the documentation and/or other materials provided
+#   with the distribution.
+# * Neither the name of {copyright_holder} nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch the cmd_vel_mux node with default configuration."""
+import ament_index_python.packages
+import launch
+import launch_ros.actions
+
+from system_globals.load_params import load_params
+from system_globals.topics import topics
+
+def generate_launch_description():
+    share_dir = ament_index_python.packages.get_package_share_directory('cmd_vel_mux')
+    # There are two different ways to pass parameters to a non-composed node;
+    # either by specifying the path to the file containing the parameters, or by
+    # passing a dictionary containing the key -> value pairs of the parameters.
+    # When starting a *composed* node on the other hand, only the dictionary
+    # style is supported.  To keep the code between the non-composed and
+    # composed launch file similar, we use that style here as well.
+    params = load_params( "cmd_vel_mux", "mux_twists.yaml")
+
+    # Remap the default topic
+    remappings = []
+    remappings.append( ("cmd_vel", topics().walking_twist_muxed) )
+    # Overwrite the config file with system globals
+    remappings.append( ("walking_twist/manual", topics().walking_twist_manual) )
+
+    cmd_vel_mux_node = launch_ros.actions.Node(
+        package='cmd_vel_mux',
+        executable='cmd_vel_mux_node',
+        output='both',
+        parameters=[params],
+        remappings=remappings,
+    )
+
+    return launch.LaunchDescription([cmd_vel_mux_node])

--- a/package.xml
+++ b/package.xml
@@ -19,19 +19,16 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>rcl_interfaces</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_components</build_depend>
-  <build_depend>rcpputils</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <depend>geometry_msgs</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rcpputils</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>rcl_interfaces</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_components</exec_depend>
-  <exec_depend>rcpputils</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <!-- Custom packages -->
+  <depend>system_globals</depend>
+
 
   <!-- <test_depend>ament_cmake_copyright</test_depend> -->
   <test_depend>ament_cmake_cppcheck</test_depend>

--- a/src/cmd_vel_mux.cpp
+++ b/src/cmd_vel_mux.cpp
@@ -48,7 +48,7 @@
 #include <vector>
 
 #include "cmd_vel_mux/cmd_vel_mux.hpp"
-#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
@@ -96,7 +96,7 @@ CmdVelMux::CmdVelMux(rclcpp::NodeOptions options):
         add_on_set_parameters_callback(
         std::bind(&CmdVelMux::parameterUpdate, this, std::placeholders::_1));
 
-    output_topic_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
+    output_topic_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("cmd_vel", 10);
     RCLCPP_DEBUG(get_logger(), "CmdVelMux : subscribe to output topic 'cmd_vel'");
 
     active_subscriber_pub_ = this->create_publisher<std_msgs::msg::String>(
@@ -201,9 +201,9 @@ void CmdVelMux::configureFromParameters(
         const std::string & key = m.first;
         const std::shared_ptr<CmdVelSub> & values = m.second;
         if (!values->sub_) {
-            values->sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+            values->sub_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
                 values->values_.topic, 10,
-                [this, key](const geometry_msgs::msg::Twist::SharedPtr msg) {cmdVelCallback(msg, key);});
+                [this, key](const geometry_msgs::msg::TwistStamped::SharedPtr msg) {cmdVelCallback(msg, key);});
         RCLCPP_DEBUG(
             get_logger(), "CmdVelMux : subscribed to '%s' on topic '%s'. pr: %" PRId64 ", to: %.2f",
             values->name_.c_str(), values->values_.topic.c_str(),
@@ -322,7 +322,8 @@ bool CmdVelMux::addInputToParameterMap(
 //=========================================================
 std::map<std::string, ParameterValues> CmdVelMux::parseFromParametersMap(
     const std::map<std::string,
-    rclcpp::Parameter> & parameters)
+    rclcpp::Parameter> & parameters
+)
 {
     std::map<std::string, ParameterValues> parsed_parameters;
     // Iterate over all parameters and parse their content
@@ -348,7 +349,7 @@ std::map<std::string, ParameterValues> CmdVelMux::parseFromParametersMap(
 
 //=========================================================
 void CmdVelMux::cmdVelCallback(
-    const std::shared_ptr<geometry_msgs::msg::Twist> msg,
+    const std::shared_ptr<geometry_msgs::msg::TwistStamped> msg,
     const std::string & key)
 {
     // if subscriber was deleted or the one being called right now just ignore

--- a/src/cmd_vel_mux.cpp
+++ b/src/cmd_vel_mux.cpp
@@ -67,361 +67,392 @@ namespace cmd_vel_mux
  *****************************************************************************/
 const char * const CmdVelMux::VACANT = "empty";
 
-CmdVelMux::CmdVelMux(rclcpp::NodeOptions options)
-: rclcpp::Node("cmd_vel_mux", options.allow_undeclared_parameters(
-      true).automatically_declare_parameters_from_overrides(true)), allowed_(VACANT)
+//=========================================================
+CmdVelMux::CmdVelMux(rclcpp::NodeOptions options):
+    rclcpp::Node(
+        "cmd_vel_mux",
+        options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true)
+    ),
+    allowed_(VACANT)
 {
-  std::map<std::string, rclcpp::Parameter> parameters;
-  // Check if there are loaded parameters from config file besides sim_time_used
-  if (!get_parameters("subscribers", parameters) || parameters.size() < 1) {
-    RCLCPP_WARN(get_logger(), "No subscribers configured!");
-  } else {
-    std::map<std::string, ParameterValues> parsed_parameters = parseFromParametersMap(parameters);
-    if (parsed_parameters.empty()) {
-      // We ran into some kind of error while configuring, quit
-      throw std::runtime_error("Invalid parameters");
+    std::map<std::string, rclcpp::Parameter> parameters;
+    // Check if there are loaded parameters from config file besides sim_time_used
+    if (!get_parameters("subscribers", parameters) || parameters.size() < 1) {
+        RCLCPP_WARN(get_logger(), "No subscribers configured!");
     }
-    if (!parametersAreValid(parsed_parameters)) {
-      throw std::runtime_error("Incomplete parameters");
-    }
-    configureFromParameters(parsed_parameters);
-  }
-
-  param_cb_ =
-    add_on_set_parameters_callback(
-    std::bind(&CmdVelMux::parameterUpdate, this, std::placeholders::_1));
-
-  output_topic_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
-  RCLCPP_DEBUG(get_logger(), "CmdVelMux : subscribe to output topic 'cmd_vel'");
-
-  active_subscriber_pub_ = this->create_publisher<std_msgs::msg::String>(
-    "active", rclcpp::QoS(1).transient_local());    // latched topic
-
-  // Notify the world that right now nobody is publishing on cmd_vel yet
-  auto active_msg = std::make_unique<std_msgs::msg::String>();
-  active_msg->data = "idle";
-  active_subscriber_pub_->publish(std::move(active_msg));
-
-  RCLCPP_DEBUG(get_logger(), "CmdVelMux : successfully initialized");
-}
-
-bool CmdVelMux::parametersAreValid(const std::map<std::string, ParameterValues> & parameters) const
-{
-  std::set<int64_t> used_priorities;
-
-  for (const std::pair<const std::string, ParameterValues> & parameter : parameters) {
-    if (parameter.second.topic.empty()) {
-      RCLCPP_WARN(get_logger(), "Empty topic for '%s'", parameter.first.c_str());
-      return false;
-    }
-    if (parameter.second.timeout < 0.0) {
-      RCLCPP_WARN(get_logger(), "Missing timeout for '%s', ignoring", parameter.first.c_str());
-      return false;
-    }
-    if (parameter.second.priority < 0) {
-      RCLCPP_WARN(get_logger(), "Missing priority for '%s', ignoring", parameter.first.c_str());
-      return false;
-    }
-    if (parameter.second.short_desc.empty()) {
-      RCLCPP_WARN(get_logger(), "Empty short_desc for '%s', ignoring", parameter.first.c_str());
-      return false;
+    else {
+        std::map<std::string, ParameterValues> parsed_parameters = parseFromParametersMap(parameters);
+        if (parsed_parameters.empty()) {
+            // We ran into some kind of error while configuring, quit
+            throw std::runtime_error("Invalid parameters");
+        }
+        if (!parametersAreValid(parsed_parameters)) {
+            throw std::runtime_error("Incomplete parameters");
+        }
+        configureFromParameters(parsed_parameters);
     }
 
-    if (used_priorities.count(parameter.second.priority) != 0) {
-      RCLCPP_WARN(get_logger(), "Cannot have duplicate priorities, ignoring");
-      return false;
-    }
-    used_priorities.insert(parameter.second.priority);
-  }
+    param_cb_ =
+        add_on_set_parameters_callback(
+        std::bind(&CmdVelMux::parameterUpdate, this, std::placeholders::_1));
 
-  return true;
-}
+    output_topic_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
+    RCLCPP_DEBUG(get_logger(), "CmdVelMux : subscribe to output topic 'cmd_vel'");
 
-void CmdVelMux::configureFromParameters(const std::map<std::string, ParameterValues> & parameters)
-{
-  std::map<std::string, std::shared_ptr<CmdVelSub>> new_map;
+    active_subscriber_pub_ = this->create_publisher<std_msgs::msg::String>(
+        "active", rclcpp::QoS(1).transient_local());    // latched topic
 
-  for (const std::pair<const std::string, ParameterValues> & parameter : parameters) {
-    const std::string & key = parameter.first;
-    const ParameterValues & parameter_values = parameter.second;
-    // Check if parameter subscriber has all its necessary values
-    if (map_.count(key) != 0) {
-      // For names already in the subscribers map, retain current
-      // object so we don't re-subscribe to the topic
-      new_map[key] = map_[key];
-    } else {
-      new_map[key] = std::make_shared<CmdVelSub>();
-    }
-
-    // update existing or new object with the new configuration
-
-    new_map[key]->name_ = key;
-    new_map[key]->values_.priority = parameter_values.priority;
-    new_map[key]->values_.short_desc = parameter_values.short_desc;
-
-    if (parameter_values.topic != new_map[key]->values_.topic) {
-      // Shutdown the topic if the name has changed so it gets recreated
-      // on configuration reload. In the case of new subscribers, topic
-      // is empty and shutdown has just no effect
-      new_map[key]->values_.topic = parameter_values.topic;
-      new_map[key]->sub_ = nullptr;
-    }
-
-    if (parameter_values.timeout != new_map[key]->values_.timeout) {
-      // Change timer period if the timeout changed
-      new_map[key]->values_.timeout = parameter_values.timeout;
-      new_map[key]->timer_ = nullptr;
-    }
-  }
-
-  // Take down the deleted subscriber if it was the one being used as source
-  if (allowed_ != VACANT && new_map.count(allowed_) == 0) {
-    allowed_ = VACANT;
-    // ...notify the world that nobody is publishing on cmd_vel; its vacant
+    // Notify the world that right now nobody is publishing on cmd_vel yet
     auto active_msg = std::make_unique<std_msgs::msg::String>();
     active_msg->data = "idle";
     active_subscriber_pub_->publish(std::move(active_msg));
-  }
 
-  map_ = new_map;
-
-  // (Re)create subscribers whose topic is invalid: new ones and those with changed names
-  for (std::pair<const std::string, std::shared_ptr<CmdVelSub>> & m : map_) {
-    const std::string & key = m.first;
-    const std::shared_ptr<CmdVelSub> & values = m.second;
-    if (!values->sub_) {
-      values->sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
-        values->values_.topic, 10,
-        [this, key](const geometry_msgs::msg::Twist::SharedPtr msg) {cmdVelCallback(msg, key);});
-      RCLCPP_DEBUG(
-        get_logger(), "CmdVelMux : subscribed to '%s' on topic '%s'. pr: %" PRId64 ", to: %.2f",
-        values->name_.c_str(), values->values_.topic.c_str(),
-        values->values_.priority, values->values_.timeout);
-    } else {
-      RCLCPP_DEBUG(
-        get_logger(), "CmdVelMux : no need to re-subscribe to input topic '%s'",
-        values->values_.topic.c_str());
-    }
-
-    if (!values->timer_) {
-      // Create (stopped by now) a one-shot timer for every subscriber, if it doesn't exist yet
-      values->timer_ = this->create_wall_timer(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-          std::chrono::duration<double>(
-            values->values_.timeout)), [this, key]() {timerCallback(key);});
-    }
-  }
-
-  RCLCPP_INFO(get_logger(), "CmdVelMux : (re)configured");
+    RCLCPP_DEBUG(get_logger(), "CmdVelMux : successfully initialized");
 }
 
+//=========================================================
+bool CmdVelMux::parametersAreValid(
+    const std::map<std::string, ParameterValues> & parameters
+) const
+{
+    std::set<int64_t> used_priorities;
+
+    for (const std::pair<const std::string, ParameterValues> & parameter : parameters) {
+        if (parameter.second.topic.empty()) {
+            RCLCPP_WARN(get_logger(), "Empty topic for '%s'", parameter.first.c_str());
+            return false;
+        }
+        if (parameter.second.timeout < 0.0) {
+            RCLCPP_WARN(get_logger(), "Missing timeout for '%s', ignoring", parameter.first.c_str());
+            return false;
+        }
+        if (parameter.second.priority < 0) {
+            RCLCPP_WARN(get_logger(), "Missing priority for '%s', ignoring", parameter.first.c_str());
+            return false;
+        }
+        if (parameter.second.short_desc.empty()) {
+            RCLCPP_WARN(get_logger(), "Empty short_desc for '%s', ignoring", parameter.first.c_str());
+            return false;
+        }
+
+        if (used_priorities.count(parameter.second.priority) != 0) {
+            RCLCPP_WARN(get_logger(), "Cannot have duplicate priorities, ignoring");
+            return false;
+        }
+        used_priorities.insert(parameter.second.priority);
+    }
+
+    return true;
+}
+
+//=========================================================
+void CmdVelMux::configureFromParameters(
+    const std::map<std::string, ParameterValues> & parameters
+)
+{
+    std::map<std::string, std::shared_ptr<CmdVelSub>> new_map;
+
+    for (const std::pair<const std::string, ParameterValues> & parameter : parameters) {
+        const std::string & key = parameter.first;
+        const ParameterValues & parameter_values = parameter.second;
+        // Check if parameter subscriber has all its necessary values
+        if (map_.count(key) != 0) {
+            // For names already in the subscribers map, retain current
+            // object so we don't re-subscribe to the topic
+            new_map[key] = map_[key];
+        }
+        else {
+            new_map[key] = std::make_shared<CmdVelSub>();
+        }
+
+        // update existing or new object with the new configuration
+        new_map[key]->name_ = key;
+        new_map[key]->values_.priority = parameter_values.priority;
+        new_map[key]->values_.short_desc = parameter_values.short_desc;
+
+        if (parameter_values.topic != new_map[key]->values_.topic) {
+            // Shutdown the topic if the name has changed so it gets recreated
+            // on configuration reload. In the case of new subscribers, topic
+            // is empty and shutdown has just no effect
+            new_map[key]->values_.topic = parameter_values.topic;
+            new_map[key]->sub_ = nullptr;
+        }
+
+        if (parameter_values.timeout != new_map[key]->values_.timeout) {
+            // Change timer period if the timeout changed
+            new_map[key]->values_.timeout = parameter_values.timeout;
+            new_map[key]->timer_ = nullptr;
+        }
+    }
+
+    // Take down the deleted subscriber if it was the one being used as source
+    if (allowed_ != VACANT && new_map.count(allowed_) == 0) {
+        allowed_ = VACANT;
+        // ...notify the world that nobody is publishing on cmd_vel; its vacant
+        auto active_msg = std::make_unique<std_msgs::msg::String>();
+        active_msg->data = "idle";
+        active_subscriber_pub_->publish(std::move(active_msg));
+    }
+
+    map_ = new_map;
+
+    // (Re)create subscribers whose topic is invalid: new ones and those with changed names
+    for (std::pair<const std::string, std::shared_ptr<CmdVelSub>> & m : map_) {
+        const std::string & key = m.first;
+        const std::shared_ptr<CmdVelSub> & values = m.second;
+        if (!values->sub_) {
+            values->sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+                values->values_.topic, 10,
+                [this, key](const geometry_msgs::msg::Twist::SharedPtr msg) {cmdVelCallback(msg, key);});
+        RCLCPP_DEBUG(
+            get_logger(), "CmdVelMux : subscribed to '%s' on topic '%s'. pr: %" PRId64 ", to: %.2f",
+            values->name_.c_str(), values->values_.topic.c_str(),
+            values->values_.priority, values->values_.timeout);
+        }
+        else {
+            RCLCPP_DEBUG(
+                get_logger(), "CmdVelMux : no need to re-subscribe to input topic '%s'",
+                values->values_.topic.c_str());
+        }
+
+        if (!values->timer_) {
+            // Create (stopped by now) a one-shot timer for every subscriber, if it doesn't exist yet
+            values->timer_ = this->create_wall_timer(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::duration<double>(
+                    values->values_.timeout)), [this, key]() {timerCallback(key);});
+        }
+    }
+
+    RCLCPP_INFO(get_logger(), "CmdVelMux : (re)configured");
+}
+
+//=========================================================
 bool CmdVelMux::addInputToParameterMap(
-  std::map<std::string, ParameterValues> & parsed_parameters,
-  const std::string & input_name,
-  const std::string & parameter_name,
-  const rclcpp::Parameter & parameter_value)
+    std::map<std::string, ParameterValues> & parsed_parameters,
+    const std::string & input_name,
+    const std::string & parameter_name,
+    const rclcpp::Parameter & parameter_value
+)
 {
-  if (parameter_name == "topic") {
-    std::string topic;
+    if (parameter_name == "topic") {
+        std::string topic;
 
-    if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
-      topic.clear();
-    } else if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_STRING) {
-      topic = parameter_value.as_string();
-    } else {
-      RCLCPP_WARN(get_logger(), "topic must be a string; ignoring");
-      return false;
-    }
-
-    if (parsed_parameters.count(input_name) == 0) {
-      parsed_parameters.emplace(std::make_pair(input_name, ParameterValues()));
-    }
-    parsed_parameters[input_name].topic = topic;
-  } else if (parameter_name == "timeout") {
-    double timeout{-1.0};
-
-    if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
-      timeout = -1.0;
-    } else if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE) {
-      timeout = parameter_value.as_double();
-    } else {
-      RCLCPP_WARN(get_logger(), "timeout must be a double; ignoring");
-      return false;
-    }
-
-    if (parsed_parameters.count(input_name) == 0) {
-      parsed_parameters.emplace(std::make_pair(input_name, ParameterValues()));
-    }
-    parsed_parameters[input_name].timeout = timeout;
-  } else if (parameter_name == "priority") {
-    int64_t priority{-1};
-
-    if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
-      priority = -1;
-    } else if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER) {
-      priority = parameter_value.as_int();
-      if (priority < 0 || priority > std::numeric_limits<uint32_t>::max()) {
-        RCLCPP_WARN(get_logger(), "Priority out of range, must be between 0 and MAX_UINT32");
+        if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
+        topic.clear();
+        } else if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_STRING) {
+        topic = parameter_value.as_string();
+        } else {
+        RCLCPP_WARN(get_logger(), "topic must be a string; ignoring");
         return false;
-      }
+        }
+
+        if (parsed_parameters.count(input_name) == 0) {
+        parsed_parameters.emplace(std::make_pair(input_name, ParameterValues()));
+        }
+        parsed_parameters[input_name].topic = topic;
+    }
+    else if (parameter_name == "timeout") {
+        double timeout{-1.0};
+
+        if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
+            timeout = -1.0;
+        }
+        else if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE) {
+            timeout = parameter_value.as_double();
+        }
+        else {
+            RCLCPP_WARN(get_logger(), "timeout must be a double; ignoring");
+            return false;
+        }
+
+        if (parsed_parameters.count(input_name) == 0) {
+            parsed_parameters.emplace(std::make_pair(input_name, ParameterValues()));
+        }
+        parsed_parameters[input_name].timeout = timeout;
+    }
+    else if (parameter_name == "priority") {
+        int64_t priority{-1};
+
+        if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
+            priority = -1;
+        }
+        else if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER) {
+            priority = parameter_value.as_int();
+            if (priority < 0 || priority > std::numeric_limits<uint32_t>::max()) {
+                RCLCPP_WARN(get_logger(), "Priority out of range, must be between 0 and MAX_UINT32");
+                return false;
+            }
+        }
+        else {
+            RCLCPP_WARN(get_logger(), "priority must be an integer; ignoring");
+            return false;
+        }
+
+        if (parsed_parameters.count(input_name) == 0) {
+            parsed_parameters.emplace(std::make_pair(input_name, ParameterValues()));
+        }
+        parsed_parameters[input_name].priority = priority;
+    }
+    else if (parameter_name == "short_desc") {
+        std::string short_desc;
+        if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
+            short_desc.clear();
+        }
+        else if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_STRING) {
+            short_desc = parameter_value.as_string();
+        }
+        else {
+            RCLCPP_WARN(get_logger(), "short_desc must be a string; ignoring");
+            return false;
+        }
+
+        if (parsed_parameters.count(input_name) == 0) {
+            parsed_parameters.emplace(std::make_pair(input_name, ParameterValues()));
+        }
+        parsed_parameters[input_name].short_desc = short_desc;
     } else {
-      RCLCPP_WARN(get_logger(), "priority must be an integer; ignoring");
-      return false;
+        RCLCPP_WARN(get_logger(), "Invalid input variable '%s'; ignored", parameter_name.c_str());
+        return false;
     }
 
-    if (parsed_parameters.count(input_name) == 0) {
-      parsed_parameters.emplace(std::make_pair(input_name, ParameterValues()));
-    }
-    parsed_parameters[input_name].priority = priority;
-  } else if (parameter_name == "short_desc") {
-    std::string short_desc;
-    if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
-      short_desc.clear();
-    } else if (parameter_value.get_type() == rclcpp::ParameterType::PARAMETER_STRING) {
-      short_desc = parameter_value.as_string();
-    } else {
-      RCLCPP_WARN(get_logger(), "short_desc must be a string; ignoring");
-      return false;
-    }
-
-    if (parsed_parameters.count(input_name) == 0) {
-      parsed_parameters.emplace(std::make_pair(input_name, ParameterValues()));
-    }
-    parsed_parameters[input_name].short_desc = short_desc;
-  } else {
-    RCLCPP_WARN(get_logger(), "Invalid input variable '%s'; ignored", parameter_name.c_str());
-    return false;
-  }
-
-  return true;
+    return true;
 }
 
+//=========================================================
 std::map<std::string, ParameterValues> CmdVelMux::parseFromParametersMap(
-  const std::map<std::string,
-  rclcpp::Parameter> & parameters)
+    const std::map<std::string,
+    rclcpp::Parameter> & parameters)
 {
-  std::map<std::string, ParameterValues> parsed_parameters;
-  // Iterate over all parameters and parse their content
-  for (const std::pair<const std::string, rclcpp::Parameter> & parameter : parameters) {
-    std::vector<std::string> splits = rcpputils::split(parameter.first, '.');
-    if (splits.size() != 2) {
-      RCLCPP_WARN(
-        get_logger(), "Invalid or unknown parameter '%s', ignoring", parameter.first.c_str());
-      continue;
+    std::map<std::string, ParameterValues> parsed_parameters;
+    // Iterate over all parameters and parse their content
+    for (const std::pair<const std::string, rclcpp::Parameter> & parameter : parameters) {
+        std::vector<std::string> splits = rcpputils::split(parameter.first, '.');
+        if (splits.size() != 2) {
+            RCLCPP_WARN(
+                get_logger(), "Invalid or unknown parameter '%s', ignoring", parameter.first.c_str());
+            continue;
+        }
+
+        const std::string & input_name = splits[0];
+        const std::string & parameter_name = splits[1];
+        const rclcpp::Parameter & parameter_value = parameter.second;
+        if (!addInputToParameterMap(parsed_parameters, input_name, parameter_name, parameter_value)) {
+            parsed_parameters.clear();
+            break;
+        }
     }
 
-    const std::string & input_name = splits[0];
-    const std::string & parameter_name = splits[1];
-    const rclcpp::Parameter & parameter_value = parameter.second;
-    if (!addInputToParameterMap(parsed_parameters, input_name, parameter_name, parameter_value)) {
-      parsed_parameters.clear();
-      break;
-    }
-  }
-
-  return parsed_parameters;
+    return parsed_parameters;
 }
 
+//=========================================================
 void CmdVelMux::cmdVelCallback(
-  const std::shared_ptr<geometry_msgs::msg::Twist> msg,
-  const std::string & key)
+    const std::shared_ptr<geometry_msgs::msg::Twist> msg,
+    const std::string & key)
 {
-  // if subscriber was deleted or the one being called right now just ignore
-  if (map_.count(key) == 0) {
-    return;
-  }
-
-  // Reset timer for this source
-  map_[key]->timer_->reset();
-
-  // Give permit to publish to this source if it's the only active or is
-  // already allowed or has higher priority that the currently allowed
-  if ((allowed_ == VACANT) ||
-    (allowed_ == key) ||
-    (map_[key]->values_.priority > map_[allowed_]->values_.priority))
-  {
-    if (allowed_ != key) {
-      allowed_ = key;
-
-      // Notify the world that a new cmd_vel source took the control
-      auto active_msg = std::make_unique<std_msgs::msg::String>();
-      active_msg->data = map_[key]->name_;
-      active_subscriber_pub_->publish(std::move(active_msg));
+    // if subscriber was deleted or the one being called right now just ignore
+    if (map_.count(key) == 0) {
+        return;
     }
 
-    output_topic_pub_->publish(*msg);
-  }
+    // Reset timer for this source
+    map_[key]->timer_->reset();
+
+    // Give permit to publish to this source if it's the only active or is
+    // already allowed or has higher priority that the currently allowed
+    if ((allowed_ == VACANT) ||
+        (allowed_ == key) ||
+        (map_[key]->values_.priority > map_[allowed_]->values_.priority))
+    {
+        if (allowed_ != key) {
+            allowed_ = key;
+
+            // Notify the world that a new cmd_vel source took the control
+            auto active_msg = std::make_unique<std_msgs::msg::String>();
+            active_msg->data = map_[key]->name_;
+            active_subscriber_pub_->publish(std::move(active_msg));
+        }
+
+        output_topic_pub_->publish(*msg);
+    }
 }
 
+//=========================================================
 // The per-topic timerCallback is continually reset as cmd_vel messages are
 // received.  Thus, if it ever expires, then the topic hasn't published within
 // the specified timeout period and it should be removed.
-void CmdVelMux::timerCallback(const std::string & key)
+void CmdVelMux::timerCallback(
+    const std::string & key
+)
 {
-  if (allowed_ == key) {
-    // No cmd_vel messages timeout happened to currently active source, so...
-    allowed_ = VACANT;
+    if (allowed_ == key) {
+        // No cmd_vel messages timeout happened to currently active source, so...
+        allowed_ = VACANT;
 
-    // ...notify the world that nobody is publishing on cmd_vel; its vacant
-    auto active_msg = std::make_unique<std_msgs::msg::String>();
-    active_msg->data = "idle";
-    active_subscriber_pub_->publish(std::move(active_msg));
-  }
+        // ...notify the world that nobody is publishing on cmd_vel; its vacant
+        auto active_msg = std::make_unique<std_msgs::msg::String>();
+        active_msg->data = "idle";
+        active_subscriber_pub_->publish(std::move(active_msg));
+    }
 }
 
+//=========================================================
 rcl_interfaces::msg::SetParametersResult CmdVelMux::parameterUpdate(
-  const std::vector<rclcpp::Parameter> & update_parameters)
+    const std::vector<rclcpp::Parameter> & update_parameters
+)
 {
-  rcl_interfaces::msg::SetParametersResult result;
-  result.successful = true;
+    rcl_interfaces::msg::SetParametersResult result;
+    result.successful = true;
 
-  std::map<std::string, rclcpp::Parameter> old_parameters;
-  if (!get_parameters("subscribers", old_parameters) || old_parameters.size() <= 1) {
-    result.successful = false;
-    result.reason = "no parameters loaded";
+    std::map<std::string, rclcpp::Parameter> old_parameters;
+    if (!get_parameters("subscribers", old_parameters) || old_parameters.size() <= 1) {
+        result.successful = false;
+        result.reason = "no parameters loaded";
+        return result;
+    }
+
+    std::map<std::string, ParameterValues> parameters = parseFromParametersMap(old_parameters);
+
+    // And then merge them
+    for (const rclcpp::Parameter & parameter : update_parameters) {
+        std::vector<std::string> splits = rcpputils::split(parameter.get_name(), '.');
+        if (splits.size() != 3) {
+            RCLCPP_WARN(
+                get_logger(), "Invalid or unknown parameter '%s', ignoring", parameter.get_name().c_str());
+            result.successful = false;
+            result.reason = "Invalid or unknown parameter";
+            break;
+        }
+        if (splits[0] != "subscribers") {
+            RCLCPP_WARN(
+                get_logger(), "Unknown parameter prefix '%s', ignoring", parameter.get_name().c_str());
+            result.successful = false;
+            result.reason = "Unknown parameter prefix";
+            break;
+        }
+
+        const std::string & input_name = splits[1];
+        const std::string & parameter_name = splits[2];
+
+        if (!addInputToParameterMap(parameters, input_name, parameter_name, parameter)) {
+            result.successful = false;
+            result.reason = "Invalid parameter";
+            break;
+        }
+    }
+
+    if (result.successful) {
+        if (parametersAreValid(parameters)) {
+            configureFromParameters(parameters);
+        }
+        else {
+            result.successful = false;
+            result.reason = "Incomplete parameters";
+        }
+    }
+
     return result;
-  }
-
-  std::map<std::string, ParameterValues> parameters = parseFromParametersMap(old_parameters);
-
-  // And then merge them
-  for (const rclcpp::Parameter & parameter : update_parameters) {
-    std::vector<std::string> splits = rcpputils::split(parameter.get_name(), '.');
-    if (splits.size() != 3) {
-      RCLCPP_WARN(
-        get_logger(), "Invalid or unknown parameter '%s', ignoring", parameter.get_name().c_str());
-      result.successful = false;
-      result.reason = "Invalid or unknown parameter";
-      break;
-    }
-    if (splits[0] != "subscribers") {
-      RCLCPP_WARN(
-        get_logger(), "Unknown parameter prefix '%s', ignoring", parameter.get_name().c_str());
-      result.successful = false;
-      result.reason = "Unknown parameter prefix";
-      break;
-    }
-
-    const std::string & input_name = splits[1];
-    const std::string & parameter_name = splits[2];
-
-    if (!addInputToParameterMap(parameters, input_name, parameter_name, parameter)) {
-      result.successful = false;
-      result.reason = "Invalid parameter";
-      break;
-    }
-  }
-
-  if (result.successful) {
-    if (parametersAreValid(parameters)) {
-      configureFromParameters(parameters);
-    } else {
-      result.successful = false;
-      result.reason = "Incomplete parameters";
-    }
-  }
-
-  return result;
 }
 
 }  // namespace cmd_vel_mux

--- a/src/cmd_vel_mux.cpp
+++ b/src/cmd_vel_mux.cpp
@@ -136,9 +136,15 @@ void CmdVelMux::cmdVelCallback(
 )
 {
     if ( checkToPublish(key) ){
-        // TODO: convert this into a stamped message
-        // output_topic_pub_->publish(*msg);
-        RCLCPP_INFO(get_logger(), "need to publish non-stamped twist"); // SAS just for debugging
+        // Convert this into a stamped message
+        geometry_msgs::msg::TwistStamped msg_stamped;
+        msg_stamped.twist = *msg;
+
+        // Add stamped properties
+        msg_stamped.header.stamp = rclcpp::Clock(RCL_ROS_TIME).now();
+        msg_stamped.header.frame_id = ""; // TODO
+
+        output_topic_pub_->publish(msg_stamped);
     }
 }
 
@@ -185,6 +191,7 @@ bool CmdVelMux::checkToPublish(
 
         return true;
     }
+    return false;
 }
 
 //=========================================================


### PR DESCRIPTION
This repo was forked off the popular `cmd_vel_mux` repo. However, it was originally designed to only work with `Twist` messages. Some of my work uses `TwistStamped` messages, while lots of open Nav packages do not add stamps. This PR updates the Mux so it can accept stamped or unstamped messages, and will publish a stamped message. 